### PR TITLE
docs: add tool calling examples and fix Go README imports

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -19,7 +19,8 @@ package main
 
 import (
     "context"
-    gonkaopenai "github.com/libermans/gonka-openai/go"
+    gonkaopenai "github.com/gonka-ai/gonka-openai/go"
+    "github.com/openai/openai-go"
 )
 
 func main() {
@@ -34,7 +35,7 @@ func main() {
     }
 
     resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-        Model: "Qwen/QwQ-32B",
+        Model: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
         Messages: []openai.ChatCompletionMessageParamUnion{
             openai.UserMessage("Hello!"),
         },
@@ -43,7 +44,7 @@ func main() {
         panic(err)
     }
 
-    println(chatCompletion.Choices[0].Message.Content)
+    println(resp.Choices[0].Message.Content)
 }
 ```
 
@@ -85,7 +86,7 @@ func main() {
     )
 
     chatCompletion, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
-        Model: "Qwen/QwQ-32B",
+        Model: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
         Messages: []openai.ChatCompletionMessageParamUnion{
             openai.UserMessage("Hello!"),
         },
@@ -99,6 +100,70 @@ func main() {
 ```
 
 This approach provides the same dynamic request signing as Option 1, but gives you more direct control over the OpenAI client configuration.
+
+## Tool Calling
+
+Only `type: "function"` is supported — vLLM implements the OpenAI chat completions spec, not the Assistants API (`code_interpreter`, `file_search` are unavailable).
+
+Define functions and the model will return structured call arguments when the user's request matches. You decide what to do with them.
+
+```go
+package main
+
+import (
+    "context"
+    "encoding/json"
+    "log"
+    "os"
+
+    gonka "github.com/gonka-ai/gonka-openai/go"
+    "github.com/openai/openai-go"
+)
+
+func main() {
+    client, err := gonka.NewGonkaOpenAI(gonka.Options{
+        GonkaPrivateKey: os.Getenv("GONKA_PRIVATE_KEY"),
+        SourceUrl:       os.Getenv("NODE_URL"),
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    resp, err := client.Chat.Completions.New(context.Background(), openai.ChatCompletionNewParams{
+        Model: "Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
+        Messages: []openai.ChatCompletionMessageParamUnion{
+            openai.UserMessage("What's the weather in Paris?"),
+        },
+        Tools: []openai.ChatCompletionToolParam{
+            {
+                Type: "function",
+                Function: openai.FunctionDefinitionParam{
+                    Name:        "get_weather",
+                    Description: openai.String("Get the current weather for a city"),
+                    Parameters: openai.FunctionParameters{
+                        "type": "object",
+                        "properties": map[string]any{
+                            "city": map[string]string{"type": "string", "description": "City name"},
+                        },
+                        "required": []string{"city"},
+                    },
+                },
+            },
+        },
+    })
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    if len(resp.Choices[0].Message.ToolCalls) > 0 {
+        call := resp.Choices[0].Message.ToolCalls[0]
+        var args struct{ City string }
+        json.Unmarshal([]byte(call.Function.Arguments), &args)
+        // model chose get_weather with {City: "Paris"} — call your function now
+        log.Printf("Tool: %s, City: %s\n", call.Function.Name, args.City)
+    }
+}
+```
 
 ## Environment Variables
 

--- a/python/README.md
+++ b/python/README.md
@@ -30,7 +30,7 @@ client = GonkaOpenAI(
 
 # Use exactly like the original OpenAI client
 response = client.chat.completions.create(
-    model="Qwen/QwQ-32B",
+    model="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
     messages=[{"role": "user", "content": "Hello! Tell me a short joke."}],
 )
 ```
@@ -61,12 +61,58 @@ client = OpenAI(
 
 # Use normally - all requests will be dynamically signed and routed through Gonka
 response = client.chat.completions.create(
-    model="Qwen/QwQ-32B",
+    model="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
     messages=[{"role": "user", "content": "What is the capital of France?"}],
 )
 ```
 
 This approach provides the same dynamic request signing as Option 1, but gives you more direct control over the OpenAI client configuration.
+
+## Tool Calling
+
+Only `type: "function"` is supported — vLLM implements the OpenAI chat completions spec, not the Assistants API (`code_interpreter`, `file_search` are unavailable).
+
+Define functions and the model will return structured call arguments when the user's request matches. You decide what to do with them.
+
+```python
+import json
+from gonka_openai import GonkaOpenAI
+
+client = GonkaOpenAI(
+    gonka_private_key="0x1234...",
+    source_url="https://api.gonka.testnet.example.com",
+)
+
+tools = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string", "description": "City name"}
+                },
+                "required": ["city"],
+            },
+        },
+    }
+]
+
+response = client.chat.completions.create(
+    model="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
+    messages=[{"role": "user", "content": "What's the weather in Paris?"}],
+    tools=tools,
+    tool_choice="auto",
+)
+
+message = response.choices[0].message
+if message.tool_calls:
+    call = message.tool_calls[0]
+    args = json.loads(call.function.arguments)
+    print(call.function.name, args)
+```
 
 ## Environment Variables
 
@@ -94,7 +140,7 @@ client = GonkaOpenAI(
 
 # Use normally
 response = client.chat.completions.create(
-    model="Qwen/QwQ-32B",
+    model="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
     messages=[{"role": "user", "content": "Hello!"}],
 )
 ```
@@ -128,7 +174,7 @@ client = GonkaOpenAI(
 
 # Use normally
 response = client.chat.completions.create(
-    model="Qwen/QwQ-32B",
+    model="Qwen/Qwen3-235B-A22B-Instruct-2507-FP8",
     messages=[{"role": "user", "content": "Hello! Tell me a short joke."}],
 )
 ```
@@ -172,7 +218,6 @@ endpoints = get_participants_with_proof(
 for e in endpoints:
     print(e.url, e.address)
 ```
-3. **Dynamic Request Signing**: Using a custom HTTP client implementation to intercept and sign each request before it's sent
 
 ## Limitations
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -26,7 +26,7 @@ const client = new GonkaOpenAI({
 
 // Use exactly like the original OpenAI client
 const response = await client.chat.completions.create({
-  model: 'Qwen/QwQ-32B',
+  model: 'Qwen/Qwen3-235B-A22B-Instruct-2507-FP8',
   messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
@@ -54,12 +54,55 @@ const client = new OpenAI({
 
 // Use normally - all requests will be dynamically signed and routed through Gonka
 const response = await client.chat.completions.create({
-  model: 'Qwen/QwQ-32B',
+  model: 'Qwen/Qwen3-235B-A22B-Instruct-2507-FP8',
   messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```
 
 This approach provides the same dynamic request signing as Option 1, but gives you more direct control over the OpenAI client configuration.
+
+## Tool Calling
+
+Only `type: "function"` is supported — vLLM implements the OpenAI chat completions spec, not the Assistants API (`code_interpreter`, `file_search` are unavailable).
+
+Define functions and the model will return structured call arguments when the user's request matches. You decide what to do with them.
+
+```typescript
+import { resolveEndpoints, GonkaOpenAI } from 'gonka-openai';
+
+const endpoints = await resolveEndpoints({ sourceUrl: 'https://gonka.example.com' });
+const client = new GonkaOpenAI({ gonkaPrivateKey: '0x1234...', endpoints });
+
+const tools = [
+  {
+    type: 'function',
+    function: {
+      name: 'get_weather',
+      description: 'Get the current weather for a city',
+      parameters: {
+        type: 'object',
+        properties: { city: { type: 'string', description: 'City name' } },
+        required: ['city'],
+      },
+    },
+  },
+];
+
+const response = await client.chat.completions.create({
+  model: 'Qwen/Qwen3-235B-A22B-Instruct-2507-FP8',
+  messages: [{ role: 'user', content: "What's the weather in Paris?" }],
+  tools,
+  tool_choice: 'auto',
+});
+
+const message = response.choices[0].message;
+if (message.tool_calls) {
+  const call = message.tool_calls[0];
+  const args = JSON.parse(call.function.arguments);
+  // model chose get_weather with { city: "Paris" } — call your function now
+  console.log(call.function.name, args);
+}
+```
 
 ## Environment Variables
 
@@ -86,7 +129,7 @@ const client = new GonkaOpenAI({ apiKey: 'mock-api-key', endpoints });
 
 // Use normally
 const response = await client.chat.completions.create({
-  model: 'Qwen/QwQ-32B',
+  model: 'Qwen/Qwen3-235B-A22B-Instruct-2507-FP8',
   messages: [{ role: 'user', content: 'Hello!' }],
 });
 ```


### PR DESCRIPTION
## Summary

- Added Tool Calling section (Go, Python, TypeScript) with working `function`-type examples
- Fixed Go Option 1 example: missing `"github.com/openai/openai-go"` import and wrong import path (`libermans` → `gonka-ai`)
- Updated model name from `Qwen/QwQ-32B` to `Qwen/Qwen3-235B-A22B-Instruct-2507-FP8` across all three READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)